### PR TITLE
Update test-and-build-image.yml

### DIFF
--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -1,10 +1,14 @@
-name: test-and-build-image
+name: test-and-build-image2
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest 
     env:
       VUE_APP_ROLLOUT_KEY: ${{ secrets.VUE_APP_ROLLOUT_KEY }}
     steps:
@@ -15,17 +19,8 @@ jobs:
       - run: npm ci
       - run: npm run test:unit
 
-      - name: Record test results to Launchable workspace
-        uses: launchableinc/record-build-and-test-results-action@v1.0.0
+      - name: publish GHA run test results
+        uses: cloudbees-io-gha/publish-test-results@v2
         with:
-          report_path: junit.xml
-          test_runner: jest
-        if: always()
-        env:
-          LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: junit.xml
-          path: junit.xml
+          test-type: junit
+          results-path: junit.xml

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -1,4 +1,4 @@
-name: test-and-build-image2
+name: test-and-build-image
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Add example of publishing GHA test results to Unify.

This change removes the broken launchable actions, and replaces it with an action that allows the GHA test results to be seen in the Unify UI -- which is a great demo of Unify-GHA integration.

See this [example of the test results ](https://cloudbees.io/cloudbees/2f05829d-ea2c-429e-7d3b-98ba87db3776/components/3c569af4-e781-412d-b4b6-122226052ea0/runs/486d2229-ed43-48d8-ad88-d5961394e5bb/09b30af2-56a8-4fa0-b39a-3131fe963573/1/logs?activeTab=Test%20Results&componentId=3c569af4-e781-412d-b4b6-122226052ea0&job=build&organizationId=2f05829d-ea2c-429e-7d3b-98ba87db3776&workflowId=486d2229-ed43-48d8-ad88-d5961394e5bb)from this PR.

<img width="1576" height="794" alt="Screenshot 2025-08-26 at 4 26 00 PM" src="https://github.com/user-attachments/assets/511a40e5-9022-4fb2-a16e-3707fd1efcee" />

Updated demo scenario:

* Onboard your HackersOrganized component
* Show that the GitHub test-and-build-image.yml workflow is visible in the Unify UI
* Open the GHA Actions interface and manually run the workflow
* Show that the GHA run is visible in the Unify UI
* After the run completes, show how the test results from the GHA run are now visible in the Unify UI. -- this is something GH doesn't support.
